### PR TITLE
add space before debug switch

### DIFF
--- a/makefile.watcom
+++ b/makefile.watcom
@@ -39,7 +39,7 @@ OBJS=malloc16.obj os2scr.obj
 !endif
 
 !ifdef DEBUG
-CFLAGS+=-d2
+CFLAGS+= -d2
 !endif
 
 OBJS+= addr.obj     &


### PR DESCRIPTION
"-l=os2v2-d2" becomes "-l=os2v2 -d2"